### PR TITLE
Add Japanese language support

### DIFF
--- a/AspNetCoreMvcLocalizationDemo/Program.cs
+++ b/AspNetCoreMvcLocalizationDemo/Program.cs
@@ -17,12 +17,13 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
         {
             new CultureInfo("zh-TW"),
             new CultureInfo("en"),
+            new CultureInfo("ja"), // Added Japanese as a supported culture
         };
     options.DefaultRequestCulture = new RequestCulture(currentCulture);
     options.SupportedCultures = supportedCultures;
     options.SupportedUICultures = supportedCultures;
 
-    // ¦b¦^À³¼ÐÀY¤¤¥[¤J Content-Language ¼ÐÀY¡A§iª¾¥Î¤áºÝ¦¹¥÷ HTTP ¤º®eªº»y¨¥¬°¦ó
+    // ï¿½bï¿½^ï¿½ï¿½ï¿½ï¿½ï¿½Yï¿½ï¿½ï¿½[ï¿½J Content-Language ï¿½ï¿½ï¿½Yï¿½Aï¿½iï¿½ï¿½ï¿½Î¤ï¿½Ý¦ï¿½ï¿½ï¿½ HTTP ï¿½ï¿½ï¿½eï¿½ï¿½ï¿½yï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
     options.ApplyCurrentCultureToResponseHeaders = true;
 });
 


### PR DESCRIPTION
Related to #1

Adds Japanese language support to the AspNetCoreMvcLocalizationDemo project.
- Adds `"ja"` to the `supportedCultures` list in `Program.cs`, enabling Japanese as a supported culture for the application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doggy8088/AspNetCoreMvcLocalizationDemo/issues/1?shareId=d15450e0-cc29-490f-9b1d-0684c0446563).