### PR TITLE
Add Japanese language support

### DIFF
--- a/AspNetCoreMvcLocalizationDemo/Program.cs
+++ b/AspNetCoreMvcLocalizationDemo/Program.cs
@@ -17,6 +17,7 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
         {
             new CultureInfo("zh-TW"),
             new CultureInfo("en"),
+            new CultureInfo("ja"), // Added Japanese as a supported culture
         };
     options.DefaultRequestCulture = new RequestCulture(currentCulture);
     options.SupportedCultures = supportedCultures;


### PR DESCRIPTION
Related to #1

Adds Japanese language support to the AspNetCoreMvcLocalizationDemo project.
- Adds `"ja"` to the `supportedCultures` list in `Program.cs`, enabling Japanese as a supported culture for the application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doggy8088/AspNetCoreMvcLocalizationDemo/issues/1?shareId=4fc3a80c-1aed-4cf1-8512-68e109fde03f).